### PR TITLE
Null check for parent logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -138,7 +138,7 @@ Logger.prototype.log = function(level, var_args) {
     var name;
     var logger = this;
     rootLogger.emit(level, logRecord);
-    while (rootLogger !== logger) {
+    while (logger && rootLogger !== logger) {
       name = logger.name
       rootLogger.emit(name, logRecord);
       logger = logger.getParent();


### PR DESCRIPTION
Hey Dan,

Parent logger is null in some cases when namespace is a single hierarchy. 

Thanks,
Satya.
